### PR TITLE
feat: ajusta lógica de paginação para exibir páginas corretamente

### DIFF
--- a/src/app/features/pokemon/components/pokemon-list/pokemon-list.component.ts
+++ b/src/app/features/pokemon/components/pokemon-list/pokemon-list.component.ts
@@ -95,12 +95,11 @@ export class PokemonListComponent implements OnInit, OnDestroy {
         this.totalPokemons = data.count;
         this.totalPages = Math.ceil(this.totalPokemons / this.limit);
         this.currentPage = Math.floor(this.offset / this.limit) + 1;
-        this.hasNextPage = !!data.next;
-        this.hasPreviousPage = !!data.previous;
+        this.hasNextPage = this.offset + this.limit < this.totalPokemons;
+        this.hasPreviousPage = this.offset > 0;
         await this.updateFavoriteStates();
       });
   }
-
   private setupFavoritesSubscription() {
     this.favoritesSubscription = this.pokemonService.favorites$.subscribe(
       () => {


### PR DESCRIPTION
This pull request updates the logic for determining pagination states in the `PokemonListComponent`. The changes simplify the conditions for `hasNextPage` and `hasPreviousPage` by directly comparing `offset` and `limit` against `totalPokemons`.

Pagination logic updates:

* [`src/app/features/pokemon/components/pokemon-list/pokemon-list.component.ts`](diffhunk://#diff-f544bd113173f41df3cdc6d69024768d46593094d0606d9aee6afa701c6aee91L98-L103): Replaced the `data.next` and `data.previous` checks with direct calculations for `hasNextPage` and `hasPreviousPage` using `offset`, `limit`, and `totalPokemons`.